### PR TITLE
Check why word statistics not written to output.tsv

### DIFF
--- a/qwen_zipf_token_stats.py
+++ b/qwen_zipf_token_stats.py
@@ -111,7 +111,12 @@ def parse_args() -> argparse.Namespace:  # noqa: D401 – simple wrapper
     parser.add_argument("--batch-size", type=int, default=1024, help="Texts per tokenizer batch")
     parser.add_argument("--num-proc", type=int, default=max(mp.cpu_count() - 1, 1), help="Number of worker processes")
     parser.add_argument("--model", default="Qwen/Qwen2_5-7B-Instruct", help="Tokenizer model name")
-    parser.add_argument("--out-file", type=Path, help="Optionally save token frequencies to file")
+    parser.add_argument(
+        "--out-file",
+        type=Path,
+        default=Path("output.tsv"),
+        help="Path to save token frequencies (TSV). Default: ./output.tsv",
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
Set default output file for token statistics to `output.tsv`.

Previously, `qwen_zipf_token_stats.py` only saved token frequencies to a file if `--out-file` was explicitly provided. This change ensures that token statistics are saved to `output.tsv` by default, addressing the user's expectation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c456b45-80e6-43c7-900b-21ab655cee47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c456b45-80e6-43c7-900b-21ab655cee47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

